### PR TITLE
cronスクリプトの追加

### DIFF
--- a/scripts/cron.daily/update_cert.sh
+++ b/scripts/cron.daily/update_cert.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# ==========================================================================
+# Let's Encrypt証明書更新スクリプト
+# ==========================================================================
+
+# 設定
+CERTBOT_VOLUME_CERTBOT="./nginx/certbot"      # Let's Encrypt用ディレクトリ
+CERTBOT_VOLUME_SSL="./nginx/ssl"              # SSL証明書ディレクトリ
+NGINX_CONTAINER_NAME="nginx"                  # Nginxコンテナ名
+CERTBOT_IMAGE="certbot/certbot"               # CertbotのDockerイメージ
+
+# ==========================================================================
+# 証明書更新
+# ==========================================================================
+
+echo "[INFO] Updating Let's Encrypt certificates..."
+
+docker run --rm \
+    -v "$CERTBOT_VOLUME_CERTBOT:/var/www/certbot" \
+    -v "$CERTBOT_VOLUME_SSL:/etc/letsencrypt" \
+    "$CERTBOT_IMAGE" renew
+
+if [ $? -eq 0 ]; then
+    echo "[INFO] Certificate renewal succeeded."
+
+    # Nginxのリロード
+    echo "[INFO] Reloading Nginx..."
+    docker exec -it "$NGINX_CONTAINER_NAME" nginx -s reload
+
+    if [ $? -eq 0 ]; then
+        echo "[INFO] Nginx reloaded successfully."
+    else
+        echo "[ERROR] Failed to reload Nginx."
+        exit 2
+    fi
+else
+    echo "[ERROR] Certificate renewal failed."
+    exit 1
+fi
+
+# 完了
+echo "[INFO] Let's Encrypt certificate renewal process completed."

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# ==========================================================================
+# インストールスクリプト
+# ==========================================================================
+echo "[INFO] Installing packages..."
+
+# パッケージのインストール
+sudo apt-get update
+sudo apt-get install -y \
+  docker \
+  docker-compose \
+  cron
+
+# crontabの編集
+echo "0 1 2 * * /home/appuser/projects/update_cert.sh" 2>&1 \
+  > /var/spool/cron/crontabs/appuser
+
+#   サービスの起動
+sudo systemctl start cron
+sudo systemctl enable cron
+
+echo "[INFO] Installation completed."


### PR DESCRIPTION
以下対応実施。
・Let's encryptによる証明書更新処理のスクリプトを追加。
・crontabに上記スクリプトを追加。(月1回。2日1時に実行。)